### PR TITLE
Stop setting column width automatically.

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -30,26 +30,6 @@ MasternodeList::MasternodeList(QWidget *parent) :
     ui->voteManyYesButton->setEnabled(false);
     ui->voteManyNoButton->setEnabled(false);
 
-    int columnAliasWidth = 100;
-    int columnAddressWidth = 200;
-    int columnProtocolWidth = 60;
-    int columnStatusWidth = 80;
-    int columnActiveWidth = 130;
-    int columnLastSeenWidth = 130;
-
-    ui->tableWidgetMyMasternodes->setColumnWidth(0, columnAliasWidth);
-    ui->tableWidgetMyMasternodes->setColumnWidth(1, columnAddressWidth);
-    ui->tableWidgetMyMasternodes->setColumnWidth(2, columnProtocolWidth);
-    ui->tableWidgetMyMasternodes->setColumnWidth(3, columnStatusWidth);
-    ui->tableWidgetMyMasternodes->setColumnWidth(4, columnActiveWidth);
-    ui->tableWidgetMyMasternodes->setColumnWidth(5, columnLastSeenWidth);
-
-    ui->tableWidgetMasternodes->setColumnWidth(0, columnAddressWidth);
-    ui->tableWidgetMasternodes->setColumnWidth(1, columnProtocolWidth);
-    ui->tableWidgetMasternodes->setColumnWidth(2, columnStatusWidth);
-    ui->tableWidgetMasternodes->setColumnWidth(3, columnActiveWidth);
-    ui->tableWidgetMasternodes->setColumnWidth(4, columnLastSeenWidth);
-
     ui->tableWidgetMyMasternodes->setContextMenuPolicy(Qt::CustomContextMenu);
 
     QAction *startAliasAction = new QAction(tr("Start alias"), this);

--- a/src/qt/systemnodelist.cpp
+++ b/src/qt/systemnodelist.cpp
@@ -30,26 +30,6 @@ SystemnodeList::SystemnodeList(QWidget *parent) :
     ui->voteManyYesButton->setEnabled(false);
     ui->voteManyNoButton->setEnabled(false);
 
-    int columnAliasWidth = 100;
-    int columnAddressWidth = 200;
-    int columnProtocolWidth = 60;
-    int columnStatusWidth = 80;
-    int columnActiveWidth = 130;
-    int columnLastSeenWidth = 130;
-
-    ui->tableWidgetMySystemnodes->setColumnWidth(0, columnAliasWidth);
-    ui->tableWidgetMySystemnodes->setColumnWidth(1, columnAddressWidth);
-    ui->tableWidgetMySystemnodes->setColumnWidth(2, columnProtocolWidth);
-    ui->tableWidgetMySystemnodes->setColumnWidth(3, columnStatusWidth);
-    ui->tableWidgetMySystemnodes->setColumnWidth(4, columnActiveWidth);
-    ui->tableWidgetMySystemnodes->setColumnWidth(5, columnLastSeenWidth);
-
-    ui->tableWidgetSystemnodes->setColumnWidth(0, columnAddressWidth);
-    ui->tableWidgetSystemnodes->setColumnWidth(1, columnProtocolWidth);
-    ui->tableWidgetSystemnodes->setColumnWidth(2, columnStatusWidth);
-    ui->tableWidgetSystemnodes->setColumnWidth(3, columnActiveWidth);
-    ui->tableWidgetSystemnodes->setColumnWidth(4, columnLastSeenWidth);
-
     ui->tableWidgetMySystemnodes->setContextMenuPolicy(Qt::CustomContextMenu);
 
     QAction *startAliasAction = new QAction(tr("Start alias"), this);


### PR DESCRIPTION
This should help with the HiRes issue on the masternode and systemnode tabs. The dashboard maximum height for transactions needs to be increased. And most popup windows will need adjustments made.


NEEDS TESTED